### PR TITLE
Setup automatic changeset publish

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,8 +4,8 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch",
+  "updateInternalDependencies": "minor",
   "ignore": []
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,12 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Create Release Pull Request
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
         uses: changesets/action@v1
+        with:
+          # This expects you to have a script called release which does a build for your packages and calls changeset publish
+          publish: npm run release
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "nx run-many -t lint",
     "build": "nx run-many -t build",
     "test": "nx run-many -t test",
-    "watch": "nx run-many -t watch"
+    "watch": "nx run-many -t watch",
+    "release": "changeset publish"
   },
   "repository": {
     "type": "git",

--- a/packages/dtcg-parser/package.json
+++ b/packages/dtcg-parser/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@udt/dtcg-parser",
+  "private": true,
   "version": "0.0.0",
   "description": "A library for parsing DTCG design token files to a Token Object Model (TOM) representation",
   "main": "dist/index.js",

--- a/packages/dtcg-serializer/package.json
+++ b/packages/dtcg-serializer/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@udt/dtcg-serializer",
+  "private": true,
   "version": "0.0.0",
   "description": "A library for serializing Token Object Models (TOM) to DTCG design token files",
   "main": "dist/index.js",

--- a/packages/dtcg2csv/package.json
+++ b/packages/dtcg2csv/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@udt/dtcg2csv",
+  "private": "true",
   "version": "0.0.0",
   "description": "A CLI utility for exporting tokens and groups from DTCG files to records in a CSV file.",
   "main": "dist/index.js",

--- a/packages/tom/package.json
+++ b/packages/tom/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@udt/tom",
+  "private": "true",
   "version": "0.0.0",
   "description": "A Token Object Model (TOM) library for creating and manipulating design tokens which is aligned to the DTCG file format",
   "main": "dist/index.js",


### PR DESCRIPTION
Should make it so that `changeset` can publish new package versions when needed. For now, only the `@udt/parser-utils` package will be released though. Everything else is marked as `private`. In due course, when the other packages are ready, we ca remove that so that they can be published too.